### PR TITLE
Temporarily redirect all traffic to ona.com

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,1 @@
+/*    https://ona.com    302!


### PR DESCRIPTION
Adds a 302 (temporary) redirect rule to Netlify configuration that redirects all pages and sub-pages to https://ona.com.

The `force = true` option ensures the redirect takes precedence over any existing content.